### PR TITLE
Omit improper dihedrals from REST2 scaling

### DIFF
--- a/meld/system/openmm_runner/transform/rest2.py
+++ b/meld/system/openmm_runner/transform/rest2.py
@@ -85,15 +85,18 @@ class REST2Transformer(TransformerBase):
             params = self.dihedral_force.getTorsionParameters(parm_index)
             i, j, k, l, mult, phi, fc = params
 
+            not_solvent = (i in nonsolvent_atoms and
+                           j in nonsolvent_atoms and
+                           k in nonsolvent_atoms and
+                           l in nonsolvent_atoms)
+
+            not_improper = (sorted([i,j]) in bond_idxs and
+                            sorted([j,k]) in bond_idxs and
+                            sorted([k,l]) in bond_idxs)
+
             # only modify dihedrals involving non-solvent atoms
             # and those where sequential atoms are bonded (proper dihedrals)
-            if (i in nonsolvent_atoms and
-                j in nonsolvent_atoms and
-                k in nonsolvent_atoms and
-                l in nonsolvent_atoms and
-                sorted([i,j]) in bond_idxs and
-                sorted([j,k]) in bond_idxs and
-                sorted([k,l]) in bond_idxs):
+            if not_solvent and not_improper:
                 self.protein_dihedrals[parm_index] = params
 
     def _find_nb_force(self, system):


### PR DESCRIPTION
The omission of improper dihedrals from REST2 scaling is expected to speed up sampling. 

There's now a proposed REST2 scaler "running" test (https://github.com/maccallumlab/meld/pull/41), but it doesn't test the functionality introduced here. So... the issue is still outstanding about how to test, but I thought I'd open this PR anyway for a place to talk about it in the main repo.

Since the transformer is just modifying dihedral parameters (no MELD restraints again?), it seems like the test could call the openMM system and check that.