### PR TITLE
Support for building explicit water/ion boxes using tleap

### DIFF
--- a/meld/system/builder.py
+++ b/meld/system/builder.py
@@ -30,16 +30,25 @@ def load_amber_system(top_filename, crd_filename, patchers=None):
 
 class SystemBuilder:
     def __init__(self, forcefield="ff14sbside", gb_radii="mbondi3",
-        explicit_solvent=False, solvent_forcefield="tip3p", solvent_distance=6
+        explicit_solvent=False, solvent_forcefield="tip3p", solvent_distance=6,
+        explicit_ions=False, p_ion="Na+", p_ioncount=0, n_ion="Cl-", n_ioncount=0
     ):
         self._forcefield = None
         self._set_forcefield(forcefield)
         self._gb_radii = None
         self._set_gb_radii(gb_radii)
+
         self._explicit_solvent = explicit_solvent
+        self._explicit_ions = explicit_ions
         if self._explicit_solvent:
             self._set_solvent_forcefield(solvent_forcefield)
             self._solvent_dist = solvent_distance
+
+            if self._explicit_ions:
+                self._set_positive_ion_type(p_ion)
+                self._p_ioncount = p_ioncount
+                self._set_negative_ion_type(n_ion)
+                self._n_ioncount = n_ioncount
 
     def build_system_from_molecules(
         self, molecules, patchers=None, leap_header_cmds=None
@@ -113,6 +122,20 @@ class SystemBuilder:
         except KeyError:
             raise RuntimeError(f"Unknown solvent_model: {solvent_model}")
 
+    def _set_positive_ion_type(self, ion_type):
+        allowed = ["Na+", "K+", "Li+", "Rb+", "Cs+", "Mg+"]
+        if ion_type not in allowed:
+            raise RuntimeError(f"Unknown ion_type: {ion_type}")
+        else:
+            self._p_ion = ion_type
+
+    def _set_negative_ion_type(self, ion_type):
+        allowed = ["Cl-", "I-", "Br-", "F-"]
+        if ion_type not in allowed:
+            raise RuntimeError(f"Unknown ion_type: {ion_type}")
+        else:
+            self._n_ion = ion_type
+
     def _generate_leap_header(self):
         leap_cmds = []
         leap_cmds.append(f"set default PBradii {self._gb_radii}")
@@ -128,6 +151,9 @@ class SystemBuilder:
             list_of_mol_ids += f"{mol_id} "
         leap_cmds.append(f"solute = combine {{ {list_of_mol_ids} }}")
         leap_cmds.append(f"solvateBox solute {self._solvent_box} {self._solvent_dist}")
+        if self._explicit_ions:
+            leap_cmds.append(f"addIons solute {self._p_ion} {self._p_ioncount}")
+            leap_cmds.append(f"addIons solute {self._n_ion} {self._n_ioncount}")
         return leap_cmds
 
     def _generate_leap_footer(self, mol_ids):

--- a/meld/system/builder.py
+++ b/meld/system/builder.py
@@ -29,11 +29,17 @@ def load_amber_system(top_filename, crd_filename, patchers=None):
 
 
 class SystemBuilder:
-    def __init__(self, forcefield="ff14sbside", gb_radii="mbondi3"):
+    def __init__(self, forcefield="ff14sbside", gb_radii="mbondi3",
+        explicit_solvent=False, solvent_forcefield="tip3p", solvent_distance=6
+    ):
         self._forcefield = None
         self._set_forcefield(forcefield)
         self._gb_radii = None
         self._set_gb_radii(gb_radii)
+        self._explicit_solvent = explicit_solvent
+        if self._explicit_solvent:
+            self._set_solvent_forcefield(solvent_forcefield)
+            self._solvent_dist = solvent_distance
 
     def build_system_from_molecules(
         self, molecules, patchers=None, leap_header_cmds=None
@@ -55,7 +61,12 @@ class SystemBuilder:
                 mol_ids.append(mol_id)
                 mol.prepare_for_tleap(mol_id)
                 leap_cmds.extend(mol.generate_tleap_input(mol_id))
-            leap_cmds.extend(self._generate_leap_footer(mol_ids))
+            if self._explicit_solvent:
+                leap_cmds.extend(self._generate_solvent(mol_ids))
+                leap_cmds.extend(self._generate_leap_footer([f"solute"]))
+            else:
+                leap_cmds.extend(self._generate_leap_footer(mol_ids))
+
             with open("tleap.in", "w") as tleap_file:
                 tleap_string = "\n".join(leap_cmds)
                 tleap_file.write(tleap_string)
@@ -81,10 +92,42 @@ class SystemBuilder:
         else:
             self._gb_radii = gb_radii
 
+    def _set_solvent_forcefield(self, solvent_forcefield):
+        ff_dict = {
+            "spce": "leaprc.water.spce",
+            "spceb": "leaprc.water.spceb",
+            "opc":  "leaprc.water.opc",
+            "tip3p": "leaprc.water.tip3p",
+            "tip4pew": "leaprc.water.tip4pew",
+        }
+        box_dict = {
+            "spce": "SPCBOX",
+            "spceb": "SPCBOX",
+            "opc":  "OPCBOX",
+            "tip3p": "TIP3PBOX",
+            "tip4pew": "TIP4PEWBOX",
+        }
+        try:
+            self._solvent_forcefield = ff_dict[solvent_forcefield]
+            self._solvent_box = box_dict[solvent_forcefield]
+        except KeyError:
+            raise RuntimeError(f"Unknown solvent_model: {solvent_model}")
+
     def _generate_leap_header(self):
         leap_cmds = []
         leap_cmds.append(f"set default PBradii {self._gb_radii}")
         leap_cmds.append(f"source {self._forcefield}")
+        if self._explicit_solvent:
+            leap_cmds.append(f"source {self._solvent_forcefield}")
+        return leap_cmds
+
+    def _generate_solvent(self, mol_ids):
+        leap_cmds = []
+        list_of_mol_ids = ""
+        for mol_id in mol_ids:
+            list_of_mol_ids += f"{mol_id} "
+        leap_cmds.append(f"solute = combine {{ {list_of_mol_ids} }}")
+        leap_cmds.append(f"solvateBox solute {self._solvent_box} {self._solvent_dist}")
         return leap_cmds
 
     def _generate_leap_footer(self, mol_ids):

--- a/meld/test/functional/test_system.py
+++ b/meld/test/functional/test_system.py
@@ -44,6 +44,7 @@ class TestCreateFromSequence(unittest.TestCase):
     def test_has_correct_residue_names(self):
         self.assertEqual(self.system.residue_names[0], "ALA")
         self.assertEqual(self.system.residue_names[-1], "ALA")
+        self.assertEqual(sum(["ALA" == res for res in self.system.residue_names]), 33)
         self.assertEqual(
             len(self.system.residue_names), self.system.coordinates.shape[0]
         )
@@ -55,6 +56,39 @@ class TestCreateFromSequence(unittest.TestCase):
     def test_temperature_scaler_defaults_to_none(self):
         self.assertEqual(self.system.temperature_scaler, None)
 
+class TestCreateFromSequenceExplicit(TestCreateFromSequence):
+    def setUp(self):
+        p = protein.ProteinMoleculeFromSequence("NALA ALA CALA")
+        b = builder.SystemBuilder(explicit_solvent=True)
+        self.system = b.build_system_from_molecules([p])
+
+    def test_has_correct_number_of_atoms(self):
+        self.assertEqual(self.system.n_atoms, 861)
+
+    def test_coordinates_have_correct_shape(self):
+        self.assertEqual(self.system.coordinates.shape[0], 861)
+        self.assertEqual(self.system.coordinates.shape[1], 3)
+
+    def test_has_correct_atom_names(self):
+        self.assertEqual(self.system.atom_names[0], "N")
+        self.assertEqual(self.system.atom_names[-1], "H2")
+        self.assertEqual(len(self.system.atom_names), self.system.coordinates.shape[0])
+
+    def test_has_correct_residue_indices(self):
+        self.assertEqual(self.system.residue_numbers[0], 1)
+        self.assertEqual(self.system.residue_numbers[-1], 279)
+        self.assertEqual(
+            len(self.system.residue_numbers), self.system.coordinates.shape[0]
+        )
+
+    def test_has_correct_residue_names(self):
+        self.assertEqual(self.system.residue_names[0], "ALA")
+        self.assertEqual(self.system.residue_names[-1], "WAT")
+        self.assertEqual(sum(["ALA" == res for res in self.system.residue_names]), 33)
+        self.assertEqual(sum(["WAT" == res for res in self.system.residue_names]), 828)
+        self.assertEqual(
+            len(self.system.residue_names), self.system.coordinates.shape[0]
+        )
 
 class TestConstantTemperatureScaler(unittest.TestCase):
     def setUp(self):
@@ -75,7 +109,6 @@ class TestConstantTemperatureScaler(unittest.TestCase):
     def test_raises_when_alpha_above_one(self):
         with self.assertRaises(RuntimeError):
             self.s(2)
-
 
 class TestLinearTemperatureScaler(unittest.TestCase):
     def setUp(self):

--- a/meld/test/functional/test_system.py
+++ b/meld/test/functional/test_system.py
@@ -90,6 +90,86 @@ class TestCreateFromSequenceExplicit(TestCreateFromSequence):
             len(self.system.residue_names), self.system.coordinates.shape[0]
         )
 
+class TestCreateFromSequenceExplicitIons(TestCreateFromSequence):
+    def setUp(self):
+        p = protein.ProteinMoleculeFromSequence("NALA ALA CALA")
+        b = builder.SystemBuilder(
+            explicit_solvent=True, explicit_ions=True,
+            p_ioncount=3, n_ioncount=3
+        )
+        self.system = b.build_system_from_molecules([p])
+
+    def test_has_correct_number_of_atoms(self):
+        self.assertEqual(self.system.n_atoms, 849)
+
+    def test_coordinates_have_correct_shape(self):
+        self.assertEqual(self.system.coordinates.shape[0], 849)
+        self.assertEqual(self.system.coordinates.shape[1], 3)
+
+    def test_has_correct_atom_names(self):
+        self.assertEqual(self.system.atom_names[0], "N")
+        self.assertEqual(self.system.atom_names[-1], "H2")
+        self.assertEqual(len(self.system.atom_names), self.system.coordinates.shape[0])
+
+    def test_has_correct_residue_indices(self):
+        self.assertEqual(self.system.residue_numbers[0], 1)
+        self.assertEqual(self.system.residue_numbers[-1], 279)
+        self.assertEqual(
+            len(self.system.residue_numbers), self.system.coordinates.shape[0]
+        )
+
+    def test_has_correct_residue_names(self):
+        self.assertEqual(self.system.residue_names[0], "ALA")
+        self.assertEqual(self.system.residue_names[-1], "WAT")
+        self.assertEqual(sum(["ALA" == res for res in self.system.residue_names]), 33)
+        self.assertEqual(sum(["WAT" == res for res in self.system.residue_names]), 810)
+        self.assertEqual(sum(["Na+" == res for res in self.system.residue_names]), 3)
+        self.assertEqual(sum(["Cl-" == res for res in self.system.residue_names]), 3)
+        self.assertEqual(
+            len(self.system.residue_names), self.system.coordinates.shape[0]
+        )
+
+class TestCreateFromSequenceExplicitIonsNeutralize(TestCreateFromSequence):
+    def setUp(self):
+        p = protein.ProteinMoleculeFromSequence("NALA GLU CALA")
+        b = builder.SystemBuilder(
+            explicit_solvent=True, explicit_ions=True
+        )
+        self.system = b.build_system_from_molecules([p])
+
+    def test_has_correct_number_of_atoms(self):
+        self.assertEqual(self.system.n_atoms, 948)
+
+    def test_coordinates_have_correct_shape(self):
+        self.assertEqual(self.system.coordinates.shape[0], 948)
+        self.assertEqual(self.system.coordinates.shape[1], 3)
+
+    def test_has_correct_atom_names(self):
+        self.assertEqual(self.system.atom_names[0], "N")
+        self.assertEqual(self.system.atom_names[-1], "H2")
+        self.assertEqual(len(self.system.atom_names), self.system.coordinates.shape[0])
+
+    def test_has_correct_residue_indices(self):
+        self.assertEqual(self.system.residue_numbers[0], 1)
+        self.assertEqual(self.system.residue_numbers[-1], 307)
+        self.assertEqual(
+            len(self.system.residue_numbers), self.system.coordinates.shape[0]
+        )
+
+    def test_has_correct_residue_names(self):
+        self.assertEqual(self.system.residue_names[0], "ALA")
+        self.assertEqual(self.system.residue_names[-1], "WAT")
+        self.assertEqual(sum(["ALA" == res for res in self.system.residue_names]), 23)
+        self.assertEqual(sum(["WAT" == res for res in self.system.residue_names]), 909)
+        self.assertEqual(sum(["Na+" == res for res in self.system.residue_names]), 1)
+        self.assertEqual(
+            len(self.system.residue_names), self.system.coordinates.shape[0]
+        )
+
+    def test_index_works(self):
+        self.assertEqual(self.system.index_of_atom(1, "N"), 1)
+        self.assertEqual(self.system.index_of_atom(3, "OXT"), 38)
+
 class TestConstantTemperatureScaler(unittest.TestCase):
     def setUp(self):
         self.s = ConstantTemperatureScaler(300.)


### PR DESCRIPTION
Fixes #46

This PR essentially just adds new parameters to `SystemBuilder` to interface with already existing tleap functionality in AmberTools/ambermini. I didn't implement the proposed enhancement where a restraining potential should be used to collapse long chains before solvating to reduce box sizes. More discussion needs to be had about the best way to do that. Lots of hardcoded values for the system sizes in the new tests of explicit water boxes. The current water box and ion replacement protocol seems deterministic, but this could be a possible breaking point if tleap algorithms changes in the future.

I'm planning to use this code for the subsequent REST2/AMAP scaling tests so we don't have to distribute as many mdcrd/top files in the test directories of the repo. 