### PR TITLE
Fix missing MAXFLOAT --> FLT_MAX

### DIFF
--- a/plugin/platforms/cuda/src/kernels/computeMeld.cu
+++ b/plugin/platforms/cuda/src/kernels/computeMeld.cu
@@ -813,7 +813,7 @@ extern "C" __global__ void evaluateAndActivate(
             if(index < end) {
                 energyScratch[i] = energyArray[indexArray[index]];
             } else {
-                energyScratch[i] = MAXFLOAT;
+                energyScratch[i] = FLT_MAX;
             }
         }
         __syncthreads();
@@ -899,7 +899,7 @@ extern "C" __global__ void evaluateAndActivateCollections(
             if(index < end) {
                 energyScratch[i] = energyArray[indexArray[index]];
             } else {
-                energyScratch[i] = MAXFLOAT;
+                energyScratch[i] = FLT_MAX;
             }
         }
         __syncthreads();


### PR DESCRIPTION
I'm working on [packaging meld with spack](https://github.com/spack/spack/pull/35783) and came across a couple of refactors that were missed.

Appears to fix #112 